### PR TITLE
ルーティングエラー回避

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,7 +9,7 @@ class ItemsController < ApplicationController
      @women = Item.display(1)
      @men = Item.display(2)
      @kids = Item.display(3)
-     @like_count = Like.where(item_id: 23).count
+    
     end
 
   def new

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -15,7 +15,7 @@
               .sell__container__inner
                 %h2.h2.sell__head 商品の情報を入力
                 = form_for @item do |f|
-                  = f.fields_for :item_image do |fin|
+                  = f.fields_for :item_images do |fin|
                     .form.sell-form
                       .sell--upload__box
                         %h3.h3.sell--upload__head
@@ -59,7 +59,7 @@
                           %i.icon-arrow-bottom
                   .sell__content.clearfix
                     %h3.sell--sub__head 配送について
-                    = link_to '?', "/jp/help_center/article/68/",class: "form__question"
+                    = link_to '?', "https://www.mercari.com/jp/help_center/article/68/",class: "form__question"
                     .sell__form__box
                       .form__group
                         %label.label
@@ -87,7 +87,7 @@
                           = f.collection_select :delivery_days_id, Days.all, :id, :name
                   .sell__content-price.clearfix
                     %h3.h3.sell--sub__head 販売価格(300〜9,999,999)
-                    = link_to '?', "/jp/help_center/article/68/",class: "form__question"
+                    = link_to '?', "https://www.mercari.com/jp/help_center/article/64/",class: "form__question"
                     .sell-form-box
                       %ul.sell__price
                         %li.form-group
@@ -109,16 +109,16 @@
                   .sell__content.sell__btn__box
                     %div
                       %p.pnote
-                        = link_to '禁止されている出品', "/jp/help_center/getting_started/prohibited_items/"
+                        = link_to '禁止されている出品', "https://www.mercari.com/jp/help_center/article/64/"
                         、
-                        = link_to '行為を必ずご確認ください。', "/jp/help_center/getting_started/prohibited_conduct/"
+                        = link_to '行為を必ずご確認ください。', "https://www.mercari.com/jp/help_center/article/64/"
                       %p.pnote
                         またブランド品でシリアルナンバー等がある場合はご記載ください。
-                        = link_to '偽ブランドの販売', "/jp/help_center/getting_started/counterfeit_goods/"
+                        = link_to '偽ブランドの販売', "https://www.mercari.com/jp/help_center/article/64/"
                         は犯罪であり処罰される可能性があります。
                       %p.pnote
                         また、出品をもちまして
-                        = link_to '加盟店規約', "/jp/seller_terms/"
+                        = link_to '加盟店規約', "https://www.mercari.com/jp/help_center/article/64/"
                         に同意したことになります。
                     = f.submit "出品する", class: "btn__default btn--red"
                     %a.btn-default.btn--gray もどる


### PR DESCRIPTION
# why
必要と判断したため

# what
出品ページから、<?>をクリックし、routesエラーになるのを回避した。
itemsコントローラの不要な記述を削除した。