### PR TITLE
商品詳細ページリンク貼り付け

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
 
-   before_action :find_params, only:[:show,:destroy,:edit]
+   
    rescue_from ActiveRecord::RecordInvalid do |exception|
     redirect_to :root, alert: 'エラーが発生しました'
   end
@@ -9,13 +9,34 @@ class ItemsController < ApplicationController
      @women = Item.display(1)
      @men = Item.display(2)
      @kids = Item.display(3)
-
     end
 
   def new
     @item = Item.new
     5.times{@item.item_images.build}
+  end
 
+  def show
+  @item = Item.find(params[:id])
+  @like = Like.where(item_id: params[:id])
+  
+  #ユーザーが投稿した商品を全て取得
+  @user_items =  Item.where(user_id: params[:id])
+  
+  # ユーザーが投稿した商品のうち、アイテム状態が１の商品のみをピック
+  @exhibiton_items = @user_items.where(status: 1)
+
+  #仮で準備。ユーザーIDが発行できるまで
+  @itemss = Item.all.order(created_at: :DESC).limit(3)
+  end
+
+  def create
+    item = Item.new(item_params)
+    if item.save
+      move_index
+    else
+      redirect_to new_item_path
+    end
   end
 
   def second
@@ -34,25 +55,11 @@ class ItemsController < ApplicationController
     end
   end
 
-  def create
-    item = Item.new(item_params)
-    if item.save
-      move_index
-    else
-      redirect_to new_item_path
-    end
-  end
-
-  def show
-    @item = Item.find(params[:id])
-  end
-
   def edit
   end
 
   def update
     item = Item.update(params_create)
-
     move_index
   end
 
@@ -96,6 +103,7 @@ def item_params
   :third_category_id,
   :status,
   item_images_attributes:[:image])
+
 end
 
 def move_index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
 
-   
+   before_action :set_item
    rescue_from ActiveRecord::RecordInvalid do |exception|
     redirect_to :root, alert: 'エラーが発生しました'
   end
@@ -17,17 +17,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-  @item = Item.find(params[:id])
-  @like = Like.where(item_id: params[:id])
-  
-  #ユーザーが投稿した商品を全て取得
-  @user_items =  Item.where(user_id: params[:id])
-  
-  # ユーザーが投稿した商品のうち、アイテム状態が１の商品のみをピック
-  @exhibiton_items = @user_items.where(status: 1)
-
-  #仮で準備。ユーザーIDが発行できるまで
-  @itemss = Item.all.order(created_at: :DESC).limit(3)
+    @item.likes
+    #ユーザーが投稿した商品を全て取得
+    user =  User.find(params[:id])
+    # ユーザーが投稿した商品のうち、アイテム状態が１の商品のみをピック
+    @exhibiton_items = user.items.where(status: 1)
+    #仮で準備。ユーザーIDが発行できるまで
+    @items = Item.all.order(created_at: :DESC).limit(3)
   end
 
   def create
@@ -104,6 +100,10 @@ def item_params
   :status,
   item_images_attributes:[:image])
 
+end
+
+def set_item
+  @item = Item.find(params[:id])
 end
 
 def move_index

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -70,7 +70,7 @@
         %button.item-button.item-button-like
           .fa.fa-heart
           %span.span いいね!
-          %span.span.fade-in-down=@like.count
+          %span.span.fade-in-down=@item.likes.count
         %a.a.item-button.item-button-report.clearfix
           .fa.fa-flag
           %span.span 不適切な商品の報告

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,83 +5,72 @@
     %h1.h1 商品タイトル
     .item-container__main-content
     .item-container__image
-      =image_tag "sample_dog.jpg", height:"220" ,width:"200" ,class:"item-image", alt: "", id: "main-box"
+      =image_tag (@item.item_images.first.image.to_s), height:"220" ,width:"200" ,class:"item-image", alt: "", id: "main-box"
       
       %ul.ul.image-slide
         %li.li
-          =image_tag "sample_dog.jpg", height:"220" ,width:"200" ,class:"item-image",alt:"", class: "slide-box"
-          =image_tag "sample_dog.jpg", height:"220" ,width:"200" ,class:"item-image",alt:"", class: "slide-box"
-
+          -  @item.item_images.each do |image|
+            = image_tag (image.image.to_s),id:"y-box",class: "slide-box"
     %table.item-container__detail
       %tbody
         %tr.tr
           %th.th 出品者
           %td.td
-            = link_to "kaw", "https://www.mercari.com/jp/u/221604517/"
-            %div.div
-              .item-user-ratings
-                %i.icon-good
-                %span.span 1272
-              .item-user-ratings
-                %i.icon-normal
-                %span.span 18
-              .item-user-ratings
-                %i.icon-bad
-                %span.span 8
+            = link_to root_path do
+              %div.div
+            .y-list-boxs-icon  
+              .y-item-user-ratings
+                %i.icon-good=image_tag ("show/icon_good"),width:18,heigh:18
+                %span.y-span 100
+              .y-item-user-ratings
+                %i.icon-normal=image_tag ("show/icon_soso"),width:20,heigh:20
+                %span.y-span 100
+              .y-item-user-ratings
+                %i.icon-bad=image_tag ("show/icon_bad"),width:20,heigh:20
+                %span.y-span 100
         %tr.tr
           %th.th カテゴリー
           %td.td
-            = link_to "第一",""
-              
-            = link_to "第二",""
-              
-            = link_to "第三",""
+           
               
         %tr.tr
           %th.th ブランド
           %td.td
-            = link_to "ブランド名",""
+          
               
         %tr.tr
           %th.th 商品のサイズ
-          %td.td M
+          %td.td 
         %tr.tr
           %th.th 商品の状態
-          %td.td 新品、未使用
+          %td.td=@item.condition.name
         %tr.tr
           %th.th 配送料の負担
-          %td.td 送料込み(出品者負担)
+          %td.td
         %tr.tr
           %th.th 配送の方法
           %td.td らくらくメルカリ便
         %tr.tr
           %th.th 配送元地域
-          %td.td
-            = link_to "新潟県" , "https://www.mercari.com/jp/area/15/"
+          %td.td=@item.prefecture.name
         %tr.tr
           %th.th 発送日の目安
-          %td.td 1~2日で発送
+          %td.td
     .item-container__price
-      %span.span.item-price ¥ 77,480
+      %span.span.item-price=@item.price
       %span.span.item-taxIn (税込)
       %span.span.item-tax-include 送料込み
     = link_to order_confirm_item_path,  class:"ditem-buy-btn" do
       購入画面に進む
     .item-description
       %p.p.item-description-inner
-        新品未使用
-        国内正規品
-        シュプリームオンライン購入
-        16FW
-        改行入れるとそのまま反映
-      
-
+        =@item.description  
     .item-button-container.clearfix
       .item-button-left
         %button.item-button.item-button-like
           .fa.fa-heart
           %span.span いいね!
-          %span.span.fade-in-down 23
+          %span.span.fade-in-down=@like.count
         %a.a.item-button.item-button-report.clearfix
           .fa.fa-flag
           %span.span 不適切な商品の報告
@@ -100,92 +89,40 @@
       %button.send コメントする
   %ul.ul.nav-item-link.clearfix
     %li.li.nav-item-link--prev
-      = link_to "週末限定セール】ノースフェイス  マカル  マウンテンジャケット","https://item.mercari.com/jp/m99259626077/"
+      = link_to "<< 前の商品",item_path
     %li.li.nav-item-link--next
-      = link_to "Tカード　シナモロール　限定品","https://item.mercari.com/jp/m13960646174/"
+      =  link_to "次の商品>>",item_path
   .item-social-media-box
     .text-center
     %ul.ul.social-media
       %li.li
-        = link_to "http://www.facebook.com/share.php?u=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm13632202360%2F", :target => "_blank",class:"share-btn" do
-          .fa.fa-facebook-square
+        .fa-facebook-square-y.k
+          = link_to "http://www.facebook.com/share.php?u=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm13632202360%2F",class:"y-share-btn" do
+            = image_tag ("show/facebooks_icon"),width:50,heigh:50
       %li.li
-        = link_to "http://twitter.com/share?count=horizontal&original_referer=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm13632202360%2F&text=Supreme%20Stars%20Zip%20S%E2%80%A6%20%28%C2%A5%2077%2C480%29%20https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm13632202360%2F%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%E3%80%8C%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%E3%80%8D%E3%81%A7%E8%B2%A9%E5%A3%B2%E4%B8%AD%E2%99%AA%20%23%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%40mercari_jp%E3%81%95%E3%82%93%E3%81%8B%E3%82%89", :target => "_blank",class:"share-btn" do
-          .fa.fa-twitter-square
+        .fa-twitter-square-y.k
+          = link_to "http://twitter.com/share?count=horizontal&original_referer=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm13632202360%2F&text=Supreme%20Stars%20Zip%20S%E2%80%A6%20%28%C2%A5%2077%2C480%29%20https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm13632202360%2F%20%E3%83%95%E3%83%AA%E3%83%9E%E3%82%A2%E3%83%97%E3%83%AA%E3%80%8C%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%E3%80%8D%E3%81%A7%E8%B2%A9%E5%A3%B2%E4%B8%AD%E2%99%AA%20%23%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%20%40mercari_jp%E3%81%95%E3%82%93%E3%81%8B%E3%82%89", :target => "_blank",class:"share-btn" do
+            = image_tag ("show/tweet_icon"),width:50,heigh:50
       %li.li
-        =link_to "http://pinterest.com/pin/create/button/?url=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm13632202360%2F&media=https%3A%2F%2Fstatic.mercdn.net%2Fitem%2Fdetail%2Forig%2Fphotos%2Fm13632202360_1.jpg%3F1544329645&description=%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%E5%95%86%E5%93%81%3A%20Supreme%20Stars%20Zip%20Stadium%20Jacket%20%E3%83%8D%E3%82%A4%E3%83%93%E3%83%BC%20M%20%23%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA", :target => "_blank",class:"share-btn" do
-          .fa.fa-pinterest-square
+        .fa-pinterest-square-y.k
+          =link_to "http://pinterest.com/pin/create/button/?url=https%3A%2F%2Fitem.mercari.com%2Fjp%2Fm13632202360%2F&media=https%3A%2F%2Fstatic.mercdn.net%2Fitem%2Fdetail%2Forig%2Fphotos%2Fm13632202360_1.jpg%3F1544329645&description=%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA%E5%95%86%E5%93%81%3A%20Supreme%20Stars%20Zip%20Stadium%20Jacket%20%E3%83%8D%E3%82%A4%E3%83%93%E3%83%BC%20M%20%23%E3%83%A1%E3%83%AB%E3%82%AB%E3%83%AA", :target => "_blank",class:"share-btn" do
+            = image_tag ("show/rakuten_icon"),width:50,heigh:50
   .items-in-user-profile
     %section.items-box-container.clearfix.items-box-overflow.items-in-user-profile
       %h2.h2.items-box-head
-        =link_to "kawさんのその他の出品", "https://www.mercari.com/jp/u/221604517/"
-      .items-box-content.clearfix
-        .item-list__cards
-          .item-list__card
-            .item-list__card-image
-              =image_tag "sample_dog.jpg", height:"220" ,width:"200" ,class:"item-image"
-            .item-list__card-info
-              .item-list__card-info-name メルカリアイテム
-              .item-list__card-info-num
-                .num__price ￥500円
-                .far.fa-heart
-                  .num-like 5
-                %p.p.item-list__card-info-tax (税込)
-          .item-list__card
-            .item-list__card-image
-              =image_tag "sample_dog.jpg", height:"220" ,width:"200" ,class:"item-image"
-            .item-list__card-info
-              .item-list__card-info-name アイテム名
-              .item-list__card-info-num
-                .num__price ￥500円
-                .far.fa-heart
-                  .num-like 5
-                %p.p.item-list__card-info-tax (税込)
-          .item-list__card
-            .item-list__card-image
-              =image_tag "sample_dog.jpg", height:"220" ,width:"200" ,class:"item-image"
-            .item-list__card-info
-              .item-list__card-info-name アイテム名
-              .item-list__card-info-num
-                .num__price ￥500円
-                .far.fa-heart
-                  .num-like 5
-                %p.p.item-list__card-info-tax (税込)
-
-    %section.items-box-container.clearfix.items-box-overflow
-      %h2.h2.items-box-head
-        =link_to  "シュプリームのブルゾン その他の商品","https://www.mercari.com/jp/brand/1620/330/"
-      .items-box-content.clearfix
-        .item-list__cards
-          .item-list__card
-            .item-list__card-image
-              =image_tag "sample_dog.jpg", height:"220" ,width:"200" ,class:"item-image"
-            .item-list__card-info
-              .item-list__card-info-name メルカリアイテム
-              .item-list__card-info-num
-                .num__price ￥500円
-                .far.fa-heart
-                  .num-like 5
-                %p.p.item-list__card-info-tax (税込)
-          .item-list__card
-            .item-list__card-image
-              =image_tag "sample_dog.jpg", height:"220" ,width:"200" ,class:"item-image"
-            .item-list__card-info
-              .item-list__card-info-name アイテム名
-              .item-list__card-info-num
-                .num__price ￥500円
-                .far.fa-heart
-                  .num-like 5
-                %p.p.item-list__card-info-tax (税込)
-          .item-list__card
-            .item-list__card-image
-              =image_tag "sample_dog.jpg", height:"220" ,width:"200" ,class:"item-image"
-            .item-list__card-info
-              .item-list__card-info-name アイテム名
-              .item-list__card-info-num
-                .num__price ￥500円
-                .far.fa-heart
-                  .num-like 5
-                %p.p.item-list__card-info-tax (税込)
+        =link_to "ユーザーの名前を入れる", "https://www.mercari.com/jp/u/221604517/"
+        .items-box-content.clearfix
+          .item-list__cards
+            -@itemss.each do |i|
+              .item-list__card
+                .item-list__card-image
+                  =image_tag (i.item_images.first.image.to_s),height:"220" ,width:"200" ,class:"item-image"
+                .item-list__card-info
+                  .item-list__card-info-name=i.name
+                  .item-list__card-info-num
+                    .num__price=i.price
+                    .far.fa-heart
+                      .num-like=Like.where(item_id: i.id).count
+                    %p.p.item-list__card-info-tax (税込)
 %footer
   = render partial: "toppage/footer"

--- a/app/views/toppage/_list-display.html.haml
+++ b/app/views/toppage/_list-display.html.haml
@@ -1,8 +1,9 @@
 .item-list__card
-  =image_tag (item.item_images.first.image.to_s),class:"item-list__card-image"
+  =link_to item_path(item.id) do
+    =image_tag (item.item_images.first.image.to_s),class:"item-list__card-image"
   .item-list__card-info
     .item-list__card-info-name 
     .item-list__card-info-num
       .num__price="#{item.price}円"
-      .far.fa-heart= Like.where(item_id: item.id).count
-      %p.item-list__card-info-tax (税込)
+      .far.fa-heart=Like.where(item_id: item.id).count
+      %p.item-list__card-info-tax (税込) 


### PR DESCRIPTION
# what
- 一覧画面から商品選択して詳細ページにリンクした。
- 詳細ページの中で、リンクを繋げる事のできるリンクを貼り付けた。
- いいねカウント数の表示。

# why

商品詳細ページの実装途中にて。
コミット及び進捗状況を共有のため

[![Image from Gyazo](https://i.gyazo.com/7cd880bc045ff49ee7640b5a6f55ada4.gif)](https://gyazo.com/7cd880bc045ff49ee7640b5a6f55ada4)