### PR TITLE
商品詳細ページの実装

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,5 +14,4 @@
 //= require rails-ujs
 //= require activestorage
 //= require_tree .
-//= require jquery
-//= require jquery_ujs
+

--- a/app/assets/javascripts/item-show.js
+++ b/app/assets/javascripts/item-show.js
@@ -1,0 +1,12 @@
+
+$(function() {
+  $('.slide-box').on("mouseover",function(){
+    $(this).css('opacity', '0.5')
+    var image = $(this).attr("src");
+    $('#main-box').attr('src',image);
+    $(this).css('opacity', '1.0')
+  })
+  $('.slide-box').on('mouseout', function(){
+        $(this).css('opacity', '0.5')
+  });
+});

--- a/app/assets/javascripts/item-show.js
+++ b/app/assets/javascripts/item-show.js
@@ -1,7 +1,6 @@
 
 $(function() {
   $('.slide-box').on("mouseover",function(){
-    $(this).css('opacity', '0.5')
     var image = $(this).attr("src");
     $('#main-box').attr('src',image);
     $(this).css('opacity', '1.0')

--- a/app/assets/stylesheets/flag.scss
+++ b/app/assets/stylesheets/flag.scss
@@ -1,8 +1,10 @@
-// 共通部分だが微調整
-.login-content__header{
+// ヘッダー部分
+.flag-header {
   margin-left: 200px;
   margin-right: 200px;
 }
+
+
 
 // mainの上部
 .flag-main__head{

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
 
 
    before_action :set_item,only:[:show]
+   before_action :authenticate_user!, only: [:show,:new]
 
    rescue_from ActiveRecord::RecordInvalid do |exception|
     redirect_to :root, alert: 'エラーが発生しました'

--- a/app/views/flags/new.html.haml
+++ b/app/views/flags/new.html.haml
@@ -1,6 +1,7 @@
 .login-content 
-  .login-content__header
-    = render 'devise/sessions/header'
+  .flag-header
+    = link_to root_path do
+      = image_tag 'header_icon.png',id:"image-style-header-logo"
   .flag-main
     = render 'flag-main'
   .login-content__footer

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -16,7 +16,6 @@
           %li.li
             -  @item.item_images.each do |image|
               = image_tag (image.image.to_s),id:"y-box",class: "slide-box"
-
     %table.item-container__detail
       %tbody
         %tr.tr


### PR DESCRIPTION
# what

- 選択画像をメイン表示する
-  未ログインユーザーが出品、投稿、詳細ページを見れないようにする
- viewの崩れを解消

# why

必要な機能なため